### PR TITLE
Solve issue with web3js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
+test-ledger
 .DS_Store
 node_modules
 target

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "pretty": "prettier --write '{,src/**/}*.ts'"
     },
     "dependencies": {
-        "@solana/web3.js": "^1.33.0",
+        "@solana/web3.js": "~1.33.0",
         "borsh": "^0.7.0",
         "fs-extra": "^10.1.0",
         "mz": "^2.7.0",


### PR DESCRIPTION
by falling back point versions. \
Also extend `.gitignore` with <test-ledger> dir.

```console
$ npm run call:1

> solana-course@0.0.1 call:1
> ts-node examples_baremetal/example1-helloworld/client/main.ts

/home/devbox/SolanaBootcamp/node_modules/@solana/web3.js/lib/index.cjs.js:644
keyMeta.isSigner ||= accountMeta.isSigner;
^

SyntaxError: Unexpected token '='
at wrapSafe (internal/modules/cjs/loader.js:915:16)
at Module._compile (internal/modules/cjs/loader.js:963:27)
at Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
at Object.require.extensions.<computed> [as .js] (/home/devbox/SolanaBootcamp/node_modules/ts-node/src/index.ts:1608:43)
at Module.load (internal/modules/cjs/loader.js:863:32)
at Function.Module._load (internal/modules/cjs/loader.js:708:14)
at Module.require (internal/modules/cjs/loader.js:887:19)
at require (internal/modules/cjs/helpers.js:74:18)
at Object.<anonymous> (/home/devbox/SolanaBootcamp/examples_baremetal/example1-helloworld/client/main.ts:4:1)
at Module._compile (internal/modules/cjs/loader.js:999:30)
```