### PR TITLE
`rust-analyzer` bursts with errors trying to find

### DIFF
--- a/examples_baremetal/Cargo.toml
+++ b/examples_baremetal/Cargo.toml
@@ -11,5 +11,5 @@ members = [
 	"example4-cpi/rust",
 	"example5-compute/rust",	
 	"example6-pda/rust",
-	"example7-access/rust",	
+#	"example7-access/rust",	
 ]


### PR DESCRIPTION
 absent ex7