### PR TITLE
Fixed `utils.ts` by replacing deprecated functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,19 @@
    solana config set --url localhost
    ```
 
-1. Run in seperate terminal window. This will spin up local solana cluster for you with RPC enpoint defaulted to `localhost:8899`, same as running `solana-test-validator --reset`
+1. Run in separate terminal window. This will spin up local solana cluster for you with RPC endpoint defaulted to `localhost:8899`, same as running `solana-test-validator --reset`
 
    ```zsh
    npm run start-local-cluster
    ```
 
-1. Monitor the logs in seperate window by running
+1. Monitor the logs in separate window by running
 
    ```zsh
     solana logs
    ```
 
-## Commans for each example
+## Commands for each example
 
 1. For each example run the following commands. The program would be deployed to the network specified in solana config
 


### PR DESCRIPTION
Updated `utils.ts` to replace deprecated functions with the latest ones. Here's how `feesEstimate` looked before:

```typescript
export async function feesEstimate(connection: Connection): Promise<number> {
  const { feeCalculator } = await connection.getRecentBlockhash();

  let fees = feeCalculator.lamportsPerSignature * 100;

  return fees;
}
```

As we can notice, `getRecentBlockhash` is deprecated and this is the main error that we get to see in our terminals after running the command `npm run call:n`. But if we replace it with the new function `getLatestBlockhash` along with some other functionalities, things work fine.

Updated `feesEstimate`:

```typescript
export async function feesEstimate(connection: Connection, payer: Keypair): Promise<number> {
  const { blockhash } = await connection.getLatestBlockhash();

  const messageArgs: MessageArgs = {
    recentBlockhash: blockhash,
    instructions: [],
    header: {
      numRequiredSignatures: 1,
      numReadonlySignedAccounts: 0,
      numReadonlyUnsignedAccounts: 0,
    },
    accountKeys: [payer.publicKey],
  }

  const message = new Message(messageArgs);
  const feeCalculator = await connection.getFeeForMessage(message);

  if (feeCalculator.value === null) {
    throw new Error("Failed to retrieve fee calculator value");
  }
  let fees = feeCalculator.value * 100;

  return fees;
}
```

One thing to notice, `feeCalculator` can't be used like before, for this we gotta create a `Message` as that's how the new function `getFeeForMessage` works.

Feel free to make edits if there's a way to optimize this new `feesEstimate` function.

Along with that, there are some typo fixes in the main README file.

Thanks!