### PR TITLE
fix: bump @solana/web3.js to resolve blockhash error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.0.1",
             "license": "MIT",
             "dependencies": {
-                "@solana/web3.js": "~1.33.0",
+                "@solana/web3.js": "^1.98.0",
                 "borsh": "^0.7.0",
                 "fs-extra": "^10.1.0",
                 "mz": "^2.7.0",
@@ -141,11 +141,12 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.22.3",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.3.tgz",
-            "integrity": "sha512-XsDuspWKLUsxwCp6r7EhsExHtYfbe5oAGQ19kqngTdCPUoPQzOPdUbD/pB9PJiwb2ptYKQDjSJT3R6dC+EPqfQ==",
+            "version": "7.26.10",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+            "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
+            "license": "MIT",
             "dependencies": {
-                "regenerator-runtime": "^0.13.11"
+                "regenerator-runtime": "^0.14.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -190,59 +191,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 4"
-            }
-        },
-        "node_modules/@ethersproject/bytes": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
-            "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ],
-            "dependencies": {
-                "@ethersproject/logger": "^5.7.0"
-            }
-        },
-        "node_modules/@ethersproject/logger": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
-            "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ]
-        },
-        "node_modules/@ethersproject/sha2": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz",
-            "integrity": "sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ],
-            "dependencies": {
-                "@ethersproject/bytes": "^5.7.0",
-                "@ethersproject/logger": "^5.7.0",
-                "hash.js": "1.1.7"
             }
         },
         "node_modules/@hapi/hoek": {
@@ -305,6 +253,33 @@
                 "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
+        "node_modules/@noble/curves": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
+            "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@noble/hashes": "1.7.1"
+            },
+            "engines": {
+                "node": "^14.21.3 || >=16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@noble/hashes": {
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+            "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+            "license": "MIT",
+            "engines": {
+                "node": "^14.21.3 || >=16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -362,9 +337,10 @@
             "dev": true
         },
         "node_modules/@solana/buffer-layout": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-3.0.0.tgz",
-            "integrity": "sha512-MVdgAKKL39tEs0l8je0hKaXLQFb7Rdfb0Xg2LjFZd8Lfdazkg6xiS98uAZrEKvaoF3i4M95ei9RydkGIDMeo3w==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.1.tgz",
+            "integrity": "sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==",
+            "license": "MIT",
             "dependencies": {
                 "buffer": "~6.0.3"
             },
@@ -372,63 +348,43 @@
                 "node": ">=5.10"
             }
         },
-        "node_modules/@solana/buffer-layout/node_modules/buffer": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "dependencies": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.2.1"
-            }
-        },
         "node_modules/@solana/web3.js": {
-            "version": "1.33.1",
-            "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.33.1.tgz",
-            "integrity": "sha512-J8Pj8pGJVy6gjvArrcAztPPzrCFLxDmQmXXU9+mPd4grOUKBwvE2UnOQE8grf/4NY/+QVJN/3AcEnWuNgLoapw==",
+            "version": "1.98.0",
+            "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.0.tgz",
+            "integrity": "sha512-nz3Q5OeyGFpFCR+erX2f6JPt3sKhzhYcSycBCSPkWjzSVDh/Rr1FqTVMRe58FKO16/ivTUcuJjeS5MyBvpkbzA==",
+            "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.12.5",
-                "@ethersproject/sha2": "^5.5.0",
-                "@solana/buffer-layout": "^3.0.0",
-                "bn.js": "^5.0.0",
-                "borsh": "^0.4.0",
+                "@babel/runtime": "^7.25.0",
+                "@noble/curves": "^1.4.2",
+                "@noble/hashes": "^1.4.0",
+                "@solana/buffer-layout": "^4.0.1",
+                "agentkeepalive": "^4.5.0",
+                "bigint-buffer": "^1.1.5",
+                "bn.js": "^5.2.1",
+                "borsh": "^0.7.0",
                 "bs58": "^4.0.1",
-                "buffer": "6.0.1",
-                "cross-fetch": "^3.1.4",
-                "jayson": "^3.4.4",
-                "js-sha3": "^0.8.0",
-                "rpc-websockets": "^7.4.2",
-                "secp256k1": "^4.0.2",
-                "superstruct": "^0.14.2",
-                "tweetnacl": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=12.20.0"
+                "buffer": "6.0.3",
+                "fast-stable-stringify": "^1.0.0",
+                "jayson": "^4.1.1",
+                "node-fetch": "^2.7.0",
+                "rpc-websockets": "^9.0.2",
+                "superstruct": "^2.0.2"
             }
         },
-        "node_modules/@solana/web3.js/node_modules/borsh": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.4.0.tgz",
-            "integrity": "sha512-aX6qtLya3K0AkT66CmYWCCDr77qsE9arV05OmdFpmat9qu8Pg9J5tBUPDztAW5fNh/d/MyVG/OYziP52Ndzx1g==",
+        "node_modules/@swc/helpers": {
+            "version": "0.5.15",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+            "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@types/bn.js": "^4.11.5",
-                "bn.js": "^5.0.0",
-                "bs58": "^4.0.0",
-                "text-encoding-utf-8": "^1.0.2"
+                "tslib": "^2.8.0"
             }
+        },
+        "node_modules/@swc/helpers/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "license": "0BSD"
         },
         "node_modules/@tsconfig/node10": {
             "version": "1.0.9",
@@ -460,18 +416,11 @@
             "integrity": "sha512-dbHBtbWBOjq0/otpopAE02NT2Cm05Qe2JsEKeCf/wjSYbI2hz8nCqnpnOJWHATgjDz4fd3dchs3Wy1gQGjfN6w==",
             "dev": true
         },
-        "node_modules/@types/bn.js": {
-            "version": "4.11.6",
-            "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
-            "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
         "node_modules/@types/connect": {
             "version": "3.4.38",
             "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
             "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+            "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
             }
@@ -536,10 +485,17 @@
             "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
             "dev": true
         },
+        "node_modules/@types/uuid": {
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+            "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+            "license": "MIT"
+        },
         "node_modules/@types/ws": {
             "version": "7.4.7",
             "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
             "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+            "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
             }
@@ -741,6 +697,18 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/agentkeepalive": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+            "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+            "license": "MIT",
+            "dependencies": {
+                "humanize-ms": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 8.0.0"
+            }
+        },
         "node_modules/ajv": {
             "version": "6.12.6",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -875,7 +843,30 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ]
+            ],
+            "license": "MIT"
+        },
+        "node_modules/bigint-buffer": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz",
+            "integrity": "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "bindings": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/bindings": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+            "license": "MIT",
+            "dependencies": {
+                "file-uri-to-path": "1.0.0"
+            }
         },
         "node_modules/bluebird": {
             "version": "3.7.2",
@@ -920,11 +911,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/brorand": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-            "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
-        },
         "node_modules/bs58": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
@@ -934,9 +920,9 @@
             }
         },
         "node_modules/buffer": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.1.tgz",
-            "integrity": "sha512-rVAXBwEcEoYtxnHSO5iWyhzV/O1WMtkUYWlfdLS7FjU4PnSJJHEfHXi/uHPI5EwltmOA794gN3bm3/pzuctWjQ==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
             "funding": [
                 {
                     "type": "github",
@@ -951,16 +937,18 @@
                     "url": "https://feross.org/support"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.2.1"
             }
         },
         "node_modules/bufferutil": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.7.tgz",
-            "integrity": "sha512-kukuqc39WOHtdxtw4UScxF/WVnMFVSQVKhtx3AjZJzhd0RGZZldcrfSEbVsWWe6KNH253574cq5F+wpv0G9pJw==",
+            "version": "4.0.9",
+            "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.9.tgz",
+            "integrity": "sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw==",
             "hasInstallScript": true,
+            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "node-gyp-build": "^4.3.0"
@@ -1036,7 +1024,8 @@
         "node_modules/commander": {
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "license": "MIT"
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
@@ -1049,14 +1038,6 @@
             "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
             "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
             "dev": true
-        },
-        "node_modules/cross-fetch": {
-            "version": "3.1.8",
-            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
-            "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
-            "dependencies": {
-                "node-fetch": "^2.6.12"
-            }
         },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
@@ -1099,6 +1080,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
             "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -1154,25 +1136,6 @@
             "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
             "dev": true
         },
-        "node_modules/elliptic": {
-            "version": "6.5.5",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.5.tgz",
-            "integrity": "sha512-7EjbcmUm17NQFu4Pmgmq2olYMj8nwMnpcddByChSUjArp8F5DQWcIcpriwO4ZToLNAJig0yiyjswfyGNje/ixw==",
-            "dependencies": {
-                "bn.js": "^4.11.9",
-                "brorand": "^1.1.0",
-                "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.1",
-                "inherits": "^2.0.4",
-                "minimalistic-assert": "^1.0.1",
-                "minimalistic-crypto-utils": "^1.0.1"
-            }
-        },
-        "node_modules/elliptic/node_modules/bn.js": {
-            "version": "4.12.0",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-            "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -1194,12 +1157,14 @@
         "node_modules/es6-promise": {
             "version": "4.2.8",
             "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-            "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+            "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+            "license": "MIT"
         },
         "node_modules/es6-promisify": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
             "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
+            "license": "MIT",
             "dependencies": {
                 "es6-promise": "^4.0.3"
             }
@@ -1494,9 +1459,10 @@
             }
         },
         "node_modules/eventemitter3": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+            "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+            "license": "MIT"
         },
         "node_modules/execa": {
             "version": "5.1.1",
@@ -1569,6 +1535,12 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
         },
+        "node_modules/fast-stable-stringify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
+            "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==",
+            "license": "MIT"
+        },
         "node_modules/fastq": {
             "version": "1.15.0",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -1589,6 +1561,12 @@
             "engines": {
                 "node": "^10.12.0 || >=12.0.0"
             }
+        },
+        "node_modules/file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+            "license": "MIT"
         },
         "node_modules/fill-range": {
             "version": "7.0.1",
@@ -1788,25 +1766,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/hash.js": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-            "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "minimalistic-assert": "^1.0.1"
-            }
-        },
-        "node_modules/hmac-drbg": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-            "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
-            "dependencies": {
-                "hash.js": "^1.0.3",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.1"
-            }
-        },
         "node_modules/human-signals": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -1814,6 +1773,15 @@
             "dev": true,
             "engines": {
                 "node": ">=10.17.0"
+            }
+        },
+        "node_modules/humanize-ms": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+            "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.0.0"
             }
         },
         "node_modules/ieee754": {
@@ -1833,7 +1801,8 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ]
+            ],
+            "license": "BSD-3-Clause"
         },
         "node_modules/ignore": {
             "version": "5.2.4",
@@ -1882,7 +1851,8 @@
         "node_modules/inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
         },
         "node_modules/is-extglob": {
             "version": "2.1.1",
@@ -1945,14 +1915,16 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
             "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+            "license": "MIT",
             "peerDependencies": {
                 "ws": "*"
             }
         },
         "node_modules/jayson": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/jayson/-/jayson-3.7.0.tgz",
-            "integrity": "sha512-tfy39KJMrrXJ+mFcMpxwBvFDetS8LAID93+rycFglIQM4kl3uNR3W4lBLE/FFhsoUCEox5Dt2adVpDm/XtebbQ==",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.1.3.tgz",
+            "integrity": "sha512-LtXh5aYZodBZ9Fc3j6f2w+MTNcnxteMOrb+QgIouguGOulWi0lieEkOUg+HkjjFs0DGoWDds6bi4E9hpNFLulQ==",
+            "license": "MIT",
             "dependencies": {
                 "@types/connect": "^3.4.33",
                 "@types/node": "^12.12.54",
@@ -1964,9 +1936,8 @@
                 "isomorphic-ws": "^4.0.1",
                 "json-stringify-safe": "^5.0.1",
                 "JSONStream": "^1.3.5",
-                "lodash": "^4.17.20",
                 "uuid": "^8.3.2",
-                "ws": "^7.4.5"
+                "ws": "^7.5.10"
             },
             "bin": {
                 "jayson": "bin/jayson.js"
@@ -1978,7 +1949,8 @@
         "node_modules/jayson/node_modules/@types/node": {
             "version": "12.20.55",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-            "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
+            "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+            "license": "MIT"
         },
         "node_modules/joi": {
             "version": "17.9.2",
@@ -1992,11 +1964,6 @@
                 "@sideway/formula": "^3.0.1",
                 "@sideway/pinpoint": "^2.0.0"
             }
-        },
-        "node_modules/js-sha3": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-            "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
@@ -2032,7 +1999,8 @@
         "node_modules/json-stringify-safe": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+            "license": "ISC"
         },
         "node_modules/jsonfile": {
             "version": "6.1.0",
@@ -2051,12 +2019,14 @@
             "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
             "engines": [
                 "node >= 0.2.0"
-            ]
+            ],
+            "license": "MIT"
         },
         "node_modules/JSONStream": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
             "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+            "license": "(MIT OR Apache-2.0)",
             "dependencies": {
                 "jsonparse": "^1.2.0",
                 "through": ">=2.2.7 <3"
@@ -2093,7 +2063,8 @@
         "node_modules/lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "dev": true
         },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
@@ -2189,16 +2160,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/minimalistic-assert": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
-        },
-        "node_modules/minimalistic-crypto-utils": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-            "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
-        },
         "node_modules/minimatch": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2223,8 +2184,7 @@
         "node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node_modules/mz": {
             "version": "2.7.0",
@@ -2242,15 +2202,11 @@
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
         },
-        "node_modules/node-addon-api": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-            "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
-        },
         "node_modules/node-fetch": {
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
             "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "license": "MIT",
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },
@@ -2267,9 +2223,11 @@
             }
         },
         "node_modules/node-gyp-build": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
-            "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
+            "version": "4.8.4",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+            "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+            "license": "MIT",
+            "optional": true,
             "bin": {
                 "node-gyp-build": "bin.js",
                 "node-gyp-build-optional": "optional.js",
@@ -2487,9 +2445,10 @@
             ]
         },
         "node_modules/regenerator-runtime": {
-            "version": "0.13.11",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-            "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+            "version": "0.14.1",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+            "license": "MIT"
         },
         "node_modules/regexpp": {
             "version": "3.2.0",
@@ -2547,12 +2506,16 @@
             }
         },
         "node_modules/rpc-websockets": {
-            "version": "7.5.1",
-            "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.5.1.tgz",
-            "integrity": "sha512-kGFkeTsmd37pHPMaHIgN1LVKXMi0JD782v4Ds9ZKtLlwdTKjn+CxM9A9/gLT2LaOuEcEFGL98h1QWQtlOIdW0w==",
+            "version": "9.1.1",
+            "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.1.1.tgz",
+            "integrity": "sha512-1IXGM/TfPT6nfYMIXkJdzn+L4JEsmb0FL1O2OBjaH03V3yuUDdKFulGLMFG6ErV+8pZ5HVC0limve01RyO+saA==",
+            "license": "LGPL-3.0-only",
             "dependencies": {
-                "@babel/runtime": "^7.17.2",
-                "eventemitter3": "^4.0.7",
+                "@swc/helpers": "^0.5.11",
+                "@types/uuid": "^8.3.4",
+                "@types/ws": "^8.2.2",
+                "buffer": "^6.0.3",
+                "eventemitter3": "^5.0.1",
                 "uuid": "^8.3.2",
                 "ws": "^8.5.0"
             },
@@ -2565,10 +2528,20 @@
                 "utf-8-validate": "^5.0.2"
             }
         },
+        "node_modules/rpc-websockets/node_modules/@types/ws": {
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.0.tgz",
+            "integrity": "sha512-8svvI3hMyvN0kKCJMvTJP/x6Y/EoQbepff882wL+Sn5QsXb3etnamgrJq4isrBxSJj5L2AuXcI0+bgkoAXGUJw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/rpc-websockets/node_modules/ws": {
-            "version": "8.13.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-            "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+            "version": "8.18.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+            "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -2641,20 +2614,6 @@
                     "url": "https://feross.org/support"
                 }
             ]
-        },
-        "node_modules/secp256k1": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.3.tgz",
-            "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
-            "hasInstallScript": true,
-            "dependencies": {
-                "elliptic": "^6.5.4",
-                "node-addon-api": "^2.0.0",
-                "node-gyp-build": "^4.2.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
         },
         "node_modules/semver": {
             "version": "7.5.1",
@@ -2823,9 +2782,13 @@
             }
         },
         "node_modules/superstruct": {
-            "version": "0.14.2",
-            "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.14.2.tgz",
-            "integrity": "sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ=="
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-2.0.2.tgz",
+            "integrity": "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
         },
         "node_modules/supports-color": {
             "version": "7.2.0",
@@ -2927,7 +2890,8 @@
         "node_modules/tr46": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "license": "MIT"
         },
         "node_modules/ts-node": {
             "version": "10.9.1",
@@ -3011,11 +2975,6 @@
                 "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
             }
         },
-        "node_modules/tweetnacl": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-            "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
-        },
         "node_modules/type-check": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3075,6 +3034,7 @@
             "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
             "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
             "hasInstallScript": true,
+            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "node-gyp-build": "^4.3.0"
@@ -3087,6 +3047,7 @@
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "license": "MIT",
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
@@ -3125,12 +3086,14 @@
         "node_modules/webidl-conversions": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "license": "BSD-2-Clause"
         },
         "node_modules/whatwg-url": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
             "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "license": "MIT",
             "dependencies": {
                 "tr46": "~0.0.3",
                 "webidl-conversions": "^3.0.0"
@@ -3167,9 +3130,10 @@
             "dev": true
         },
         "node_modules/ws": {
-            "version": "7.5.9",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-            "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+            "version": "7.5.10",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8.3.0"
             },
@@ -3296,11 +3260,11 @@
             }
         },
         "@babel/runtime": {
-            "version": "7.22.3",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.3.tgz",
-            "integrity": "sha512-XsDuspWKLUsxwCp6r7EhsExHtYfbe5oAGQ19kqngTdCPUoPQzOPdUbD/pB9PJiwb2ptYKQDjSJT3R6dC+EPqfQ==",
+            "version": "7.26.10",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+            "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
             "requires": {
-                "regenerator-runtime": "^0.13.11"
+                "regenerator-runtime": "^0.14.0"
             }
         },
         "@cspotcode/source-map-support": {
@@ -3335,29 +3299,6 @@
                     "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
                     "dev": true
                 }
-            }
-        },
-        "@ethersproject/bytes": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
-            "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
-            "requires": {
-                "@ethersproject/logger": "^5.7.0"
-            }
-        },
-        "@ethersproject/logger": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
-            "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig=="
-        },
-        "@ethersproject/sha2": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz",
-            "integrity": "sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==",
-            "requires": {
-                "@ethersproject/bytes": "^5.7.0",
-                "@ethersproject/logger": "^5.7.0",
-                "hash.js": "1.1.7"
             }
         },
         "@hapi/hoek": {
@@ -3414,6 +3355,19 @@
                 "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
+        "@noble/curves": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
+            "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+            "requires": {
+                "@noble/hashes": "1.7.1"
+            }
+        },
+        "@noble/hashes": {
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+            "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="
+        },
         "@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3462,55 +3416,47 @@
             "dev": true
         },
         "@solana/buffer-layout": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-3.0.0.tgz",
-            "integrity": "sha512-MVdgAKKL39tEs0l8je0hKaXLQFb7Rdfb0Xg2LjFZd8Lfdazkg6xiS98uAZrEKvaoF3i4M95ei9RydkGIDMeo3w==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.1.tgz",
+            "integrity": "sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==",
             "requires": {
                 "buffer": "~6.0.3"
-            },
-            "dependencies": {
-                "buffer": {
-                    "version": "6.0.3",
-                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-                    "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-                    "requires": {
-                        "base64-js": "^1.3.1",
-                        "ieee754": "^1.2.1"
-                    }
-                }
             }
         },
         "@solana/web3.js": {
-            "version": "1.33.1",
-            "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.33.1.tgz",
-            "integrity": "sha512-J8Pj8pGJVy6gjvArrcAztPPzrCFLxDmQmXXU9+mPd4grOUKBwvE2UnOQE8grf/4NY/+QVJN/3AcEnWuNgLoapw==",
+            "version": "1.98.0",
+            "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.0.tgz",
+            "integrity": "sha512-nz3Q5OeyGFpFCR+erX2f6JPt3sKhzhYcSycBCSPkWjzSVDh/Rr1FqTVMRe58FKO16/ivTUcuJjeS5MyBvpkbzA==",
             "requires": {
-                "@babel/runtime": "^7.12.5",
-                "@ethersproject/sha2": "^5.5.0",
-                "@solana/buffer-layout": "^3.0.0",
-                "bn.js": "^5.0.0",
-                "borsh": "^0.4.0",
+                "@babel/runtime": "^7.25.0",
+                "@noble/curves": "^1.4.2",
+                "@noble/hashes": "^1.4.0",
+                "@solana/buffer-layout": "^4.0.1",
+                "agentkeepalive": "^4.5.0",
+                "bigint-buffer": "^1.1.5",
+                "bn.js": "^5.2.1",
+                "borsh": "^0.7.0",
                 "bs58": "^4.0.1",
-                "buffer": "6.0.1",
-                "cross-fetch": "^3.1.4",
-                "jayson": "^3.4.4",
-                "js-sha3": "^0.8.0",
-                "rpc-websockets": "^7.4.2",
-                "secp256k1": "^4.0.2",
-                "superstruct": "^0.14.2",
-                "tweetnacl": "^1.0.0"
+                "buffer": "6.0.3",
+                "fast-stable-stringify": "^1.0.0",
+                "jayson": "^4.1.1",
+                "node-fetch": "^2.7.0",
+                "rpc-websockets": "^9.0.2",
+                "superstruct": "^2.0.2"
+            }
+        },
+        "@swc/helpers": {
+            "version": "0.5.15",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+            "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+            "requires": {
+                "tslib": "^2.8.0"
             },
             "dependencies": {
-                "borsh": {
-                    "version": "0.4.0",
-                    "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.4.0.tgz",
-                    "integrity": "sha512-aX6qtLya3K0AkT66CmYWCCDr77qsE9arV05OmdFpmat9qu8Pg9J5tBUPDztAW5fNh/d/MyVG/OYziP52Ndzx1g==",
-                    "requires": {
-                        "@types/bn.js": "^4.11.5",
-                        "bn.js": "^5.0.0",
-                        "bs58": "^4.0.0",
-                        "text-encoding-utf-8": "^1.0.2"
-                    }
+                "tslib": {
+                    "version": "2.8.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
                 }
             }
         },
@@ -3543,14 +3489,6 @@
             "resolved": "https://registry.npmjs.org/@tsconfig/recommended/-/recommended-1.0.2.tgz",
             "integrity": "sha512-dbHBtbWBOjq0/otpopAE02NT2Cm05Qe2JsEKeCf/wjSYbI2hz8nCqnpnOJWHATgjDz4fd3dchs3Wy1gQGjfN6w==",
             "dev": true
-        },
-        "@types/bn.js": {
-            "version": "4.11.6",
-            "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
-            "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
-            "requires": {
-                "@types/node": "*"
-            }
         },
         "@types/connect": {
             "version": "3.4.38",
@@ -3619,6 +3557,11 @@
             "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
             "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
             "dev": true
+        },
+        "@types/uuid": {
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+            "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
         },
         "@types/ws": {
             "version": "7.4.7",
@@ -3739,6 +3682,14 @@
             "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
             "dev": true
         },
+        "agentkeepalive": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+            "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+            "requires": {
+                "humanize-ms": "^1.2.1"
+            }
+        },
         "ajv": {
             "version": "6.12.6",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -3839,6 +3790,22 @@
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
         },
+        "bigint-buffer": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz",
+            "integrity": "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==",
+            "requires": {
+                "bindings": "^1.3.0"
+            }
+        },
+        "bindings": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+            "requires": {
+                "file-uri-to-path": "1.0.0"
+            }
+        },
         "bluebird": {
             "version": "3.7.2",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -3879,11 +3846,6 @@
                 "fill-range": "^7.0.1"
             }
         },
-        "brorand": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-            "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
-        },
         "bs58": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
@@ -3893,18 +3855,18 @@
             }
         },
         "buffer": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.1.tgz",
-            "integrity": "sha512-rVAXBwEcEoYtxnHSO5iWyhzV/O1WMtkUYWlfdLS7FjU4PnSJJHEfHXi/uHPI5EwltmOA794gN3bm3/pzuctWjQ==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
             "requires": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.2.1"
             }
         },
         "bufferutil": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.7.tgz",
-            "integrity": "sha512-kukuqc39WOHtdxtw4UScxF/WVnMFVSQVKhtx3AjZJzhd0RGZZldcrfSEbVsWWe6KNH253574cq5F+wpv0G9pJw==",
+            "version": "4.0.9",
+            "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.9.tgz",
+            "integrity": "sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw==",
             "optional": true,
             "requires": {
                 "node-gyp-build": "^4.3.0"
@@ -3973,14 +3935,6 @@
             "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
             "dev": true
         },
-        "cross-fetch": {
-            "version": "3.1.8",
-            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
-            "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
-            "requires": {
-                "node-fetch": "^2.6.12"
-            }
-        },
         "cross-spawn": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -4047,27 +4001,6 @@
             "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
             "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
             "dev": true
-        },
-        "elliptic": {
-            "version": "6.5.5",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.5.tgz",
-            "integrity": "sha512-7EjbcmUm17NQFu4Pmgmq2olYMj8nwMnpcddByChSUjArp8F5DQWcIcpriwO4ZToLNAJig0yiyjswfyGNje/ixw==",
-            "requires": {
-                "bn.js": "^4.11.9",
-                "brorand": "^1.1.0",
-                "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.1",
-                "inherits": "^2.0.4",
-                "minimalistic-assert": "^1.0.1",
-                "minimalistic-crypto-utils": "^1.0.1"
-            },
-            "dependencies": {
-                "bn.js": {
-                    "version": "4.12.0",
-                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-                    "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-                }
-            }
         },
         "emoji-regex": {
             "version": "8.0.0",
@@ -4306,9 +4239,9 @@
             }
         },
         "eventemitter3": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+            "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
         },
         "execa": {
             "version": "5.1.1",
@@ -4369,6 +4302,11 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
         },
+        "fast-stable-stringify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
+            "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag=="
+        },
         "fastq": {
             "version": "1.15.0",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -4386,6 +4324,11 @@
             "requires": {
                 "flat-cache": "^3.0.4"
             }
+        },
+        "file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
         },
         "fill-range": {
             "version": "7.0.1",
@@ -4526,30 +4469,19 @@
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "dev": true
         },
-        "hash.js": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-            "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-            "requires": {
-                "inherits": "^2.0.3",
-                "minimalistic-assert": "^1.0.1"
-            }
-        },
-        "hmac-drbg": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-            "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
-            "requires": {
-                "hash.js": "^1.0.3",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.1"
-            }
-        },
         "human-signals": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
             "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
             "dev": true
+        },
+        "humanize-ms": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+            "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+            "requires": {
+                "ms": "^2.0.0"
+            }
         },
         "ieee754": {
             "version": "1.2.1",
@@ -4591,7 +4523,8 @@
         "inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
         },
         "is-extglob": {
             "version": "2.1.1",
@@ -4639,9 +4572,9 @@
             "requires": {}
         },
         "jayson": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/jayson/-/jayson-3.7.0.tgz",
-            "integrity": "sha512-tfy39KJMrrXJ+mFcMpxwBvFDetS8LAID93+rycFglIQM4kl3uNR3W4lBLE/FFhsoUCEox5Dt2adVpDm/XtebbQ==",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.1.3.tgz",
+            "integrity": "sha512-LtXh5aYZodBZ9Fc3j6f2w+MTNcnxteMOrb+QgIouguGOulWi0lieEkOUg+HkjjFs0DGoWDds6bi4E9hpNFLulQ==",
             "requires": {
                 "@types/connect": "^3.4.33",
                 "@types/node": "^12.12.54",
@@ -4653,9 +4586,8 @@
                 "isomorphic-ws": "^4.0.1",
                 "json-stringify-safe": "^5.0.1",
                 "JSONStream": "^1.3.5",
-                "lodash": "^4.17.20",
                 "uuid": "^8.3.2",
-                "ws": "^7.4.5"
+                "ws": "^7.5.10"
             },
             "dependencies": {
                 "@types/node": {
@@ -4677,11 +4609,6 @@
                 "@sideway/formula": "^3.0.1",
                 "@sideway/pinpoint": "^2.0.0"
             }
-        },
-        "js-sha3": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-            "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
         },
         "js-tokens": {
             "version": "4.0.0",
@@ -4758,7 +4685,8 @@
         "lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "dev": true
         },
         "lodash.merge": {
             "version": "4.6.2",
@@ -4836,16 +4764,6 @@
             "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
             "dev": true
         },
-        "minimalistic-assert": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
-        },
-        "minimalistic-crypto-utils": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-            "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
-        },
         "minimatch": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4864,8 +4782,7 @@
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "mz": {
             "version": "2.7.0",
@@ -4883,11 +4800,6 @@
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
         },
-        "node-addon-api": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-            "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
-        },
         "node-fetch": {
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -4897,9 +4809,10 @@
             }
         },
         "node-gyp-build": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
-            "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ=="
+            "version": "4.8.4",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+            "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+            "optional": true
         },
         "npm-run-path": {
             "version": "4.0.1",
@@ -5038,9 +4951,9 @@
             "dev": true
         },
         "regenerator-runtime": {
-            "version": "0.13.11",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-            "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+            "version": "0.14.1",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
         },
         "regexpp": {
             "version": "3.2.0",
@@ -5076,22 +4989,33 @@
             }
         },
         "rpc-websockets": {
-            "version": "7.5.1",
-            "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.5.1.tgz",
-            "integrity": "sha512-kGFkeTsmd37pHPMaHIgN1LVKXMi0JD782v4Ds9ZKtLlwdTKjn+CxM9A9/gLT2LaOuEcEFGL98h1QWQtlOIdW0w==",
+            "version": "9.1.1",
+            "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.1.1.tgz",
+            "integrity": "sha512-1IXGM/TfPT6nfYMIXkJdzn+L4JEsmb0FL1O2OBjaH03V3yuUDdKFulGLMFG6ErV+8pZ5HVC0limve01RyO+saA==",
             "requires": {
-                "@babel/runtime": "^7.17.2",
+                "@swc/helpers": "^0.5.11",
+                "@types/uuid": "^8.3.4",
+                "@types/ws": "^8.2.2",
+                "buffer": "^6.0.3",
                 "bufferutil": "^4.0.1",
-                "eventemitter3": "^4.0.7",
+                "eventemitter3": "^5.0.1",
                 "utf-8-validate": "^5.0.2",
                 "uuid": "^8.3.2",
                 "ws": "^8.5.0"
             },
             "dependencies": {
+                "@types/ws": {
+                    "version": "8.18.0",
+                    "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.0.tgz",
+                    "integrity": "sha512-8svvI3hMyvN0kKCJMvTJP/x6Y/EoQbepff882wL+Sn5QsXb3etnamgrJq4isrBxSJj5L2AuXcI0+bgkoAXGUJw==",
+                    "requires": {
+                        "@types/node": "*"
+                    }
+                },
                 "ws": {
-                    "version": "8.13.0",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-                    "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+                    "version": "8.18.1",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+                    "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
                     "requires": {}
                 }
             }
@@ -5126,16 +5050,6 @@
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        },
-        "secp256k1": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.3.tgz",
-            "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
-            "requires": {
-                "elliptic": "^6.5.4",
-                "node-addon-api": "^2.0.0",
-                "node-gyp-build": "^4.2.0"
-            }
         },
         "semver": {
             "version": "7.5.1",
@@ -5257,9 +5171,9 @@
             "dev": true
         },
         "superstruct": {
-            "version": "0.14.2",
-            "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.14.2.tgz",
-            "integrity": "sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ=="
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-2.0.2.tgz",
+            "integrity": "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A=="
         },
         "supports-color": {
             "version": "7.2.0",
@@ -5399,11 +5313,6 @@
                 "tslib": "^1.8.1"
             }
         },
-        "tweetnacl": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-            "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
-        },
         "type-check": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -5514,9 +5423,9 @@
             "dev": true
         },
         "ws": {
-            "version": "7.5.9",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-            "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+            "version": "7.5.10",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
             "requires": {}
         },
         "yallist": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "pretty": "prettier --write '{,src/**/}*.ts'"
     },
     "dependencies": {
-        "@solana/web3.js": "~1.33.0",
+        "@solana/web3.js": "^1.98.0",
         "borsh": "^0.7.0",
         "fs-extra": "^10.1.0",
         "mz": "^2.7.0",


### PR DESCRIPTION
Solana RPC no longer supports getRecentBlockhash, leading to transaction failures.

Older versions of @solana/web3.js attempted to call it, resulting in the error: "failed to get recent blockhash: Method not found at Connection.getRecentBlockhash."

Upgrading to ^1.98.0 ensures compatibility with the latest Solana RPC API.